### PR TITLE
Add FRONTAIL_OPTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ CMD frontail \
     --theme ${FRONTAIL_THEME}\
     -l 2000 \
     -n 200 \
+    ${FRONTAIL_OPTS} \
     /var/log/openhab/events.log \
     /var/log/openhab/openhab.log

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ docker run -d \
 
 The dark theme can be enabled by setting the `FRONTAIL_THEME` environment variable. To do this just add `-e FRONTAIL_THEME=openhab_dark` to your docker run arguments.
 
+#### Apply additional options
+
+To pass additional options to frontail the environment variable `FRONTAIL_OPTS` can be set. For example, when running behind a reverse proxy add `-e "FRONTAIL_OPTS=--url-path /frontail"`.
+
 ## License
 
 MIT (c) 2018 Han Verstraete https://github.com/welteki


### PR DESCRIPTION
Hi,
first thanks for your work on this.

I use the image behind a reverse proxy on a sub-path on the same domain as openhab itself, so I need to pass url-path to frontail.
This patch adds an environment variable to allow updates in a generic way.